### PR TITLE
Update doc for resource parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ if (!isset($_GET['code'])) {
 
     // Try to get an access token (using the authorization code grant)
     $token = $provider->getAccessToken('authorization_code', [
-        'code' => $_GET['code']
+        'code' => $_GET['code'],
+        'resource' => 'https://graph.windows.net',
     ]);
 
     // Optional: Now you have a token you can look up a users profile data


### PR DESCRIPTION
For some reason we have to specify the 'resource' parameter in the request in order to access the graph API, so i've updated the doc so people won't spend hours trying to find why their token is not accepted.
