### PR TITLE
Allow php-jwt 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=5.5.0",
         "league/oauth2-client": "~1.4",
-        "firebase/php-jwt": "~3.0|~4.0"
+        "firebase/php-jwt": "~3.0||~4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=5.5.0",
         "league/oauth2-client": "~1.4",
-        "firebase/php-jwt": "~4.0"
+        "firebase/php-jwt": "~3.0|~4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=5.5.0",
         "league/oauth2-client": "~1.4",
-        "firebase/php-jwt": "~3.0"
+        "firebase/php-jwt": "~4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
firebase\php-jwt 3.0 and 4.0 are backwards compatible.