### PR TITLE
Added option to change scope separator

### DIFF
--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -20,7 +20,7 @@ class Azure extends AbstractProvider
     public $pathToken = "/oauth2/token";
     
     public $scope = [];
-    public $scopeSeparator = ",";
+    public $scopeSeparator = " ";
 
     public $tenant = "common";
 

--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -20,6 +20,7 @@ class Azure extends AbstractProvider
     public $pathToken = "/oauth2/token";
     
     public $scope = [];
+    public $scopeSeparator = ",";
 
     public $tenant = "common";
 
@@ -78,6 +79,11 @@ class Azure extends AbstractProvider
     protected function getDefaultScopes()
     {
         return $this->scope;
+    }
+
+    protected function getScopeSeparator()
+    {
+        return $this->scopeSeparator;
     }
     
     protected function createAccessToken(array $response, AbstractGrant $grant)


### PR DESCRIPTION
I am trying to get oauth2-azure to work with the Azure AD 2.0 endpoint, and it works, apart from the fact that there is one feature I am missing: An override for the scope separator. 

```php
$provider = new \TheNetworg\OAuth2\Client\Provider\Azure([
            'clientId' => ONEDRIVE_CLIENT_ID,
            'clientSecret' => ONEDRIVE_SECRET,
            'redirectUri' => WEB_ADDRESS . PATH_PREFIX . "/confirm/onedrive",
        ]);

        $provider->urlAPI = "https://graph.microsoft.com/v1.0/";
        $provider->resource = "https://graph.microsoft.com/";
        $provider->pathAuthorize = "/oauth2/v2.0/authorize";
        $provider->pathToken = "/oauth2/v2.0/token";
        $provider->authWithResource = false;

        $options = [
            'scope' => ['https://graph.microsoft.com/User.Read', 'https://graph.microsoft.com/Files.Read.All', 'offline_access'],
            'prompt' => 'consent',
        ];
        $authUrl = $provider->getAuthorizationUrl($options);
```

This works fine, apart from when a non-Microsoft account tries to sign in, when an `invalid_resource` error is returned, stating that it can't find the resource https://graph.microsoft.com/User.Read,https://graph.microsoft.com

Upon resourcing this issue, I found that this document (https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-compare) lists the following example:
```
GET https://login.microsoftonline.com/common/oauth2/v2.0/authorize?
client_id=2d4d11a2-f814-46a7-890a-274a72a7309e
&scope=https%3A%2F%2Fgraph.windows.net%2Fdirectory.read%20https%3A%2F%2Fgraph.windows.net%2Fdirectory.write
...
```
Where the scopes are separated by %20 (spaces), rather than %2C (commas). Manually changing the authentication URL indeed resolved the issue, hence this pull request.