### PR TITLE
Branch v2.0.0 fixes

### DIFF
--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -111,6 +111,11 @@ class Azure extends AbstractProvider
     {
         return [];
     }
+
+  	protected function getScopeSeparator()
+  	{
+  		return ' ';
+  	}
     
     protected function createAccessToken(array $response, AbstractGrant $grant)
     {

--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -18,29 +18,29 @@ class Azure extends AbstractProvider
     protected $metadata = "https://login.microsoftonline.com/common/.well-known/openid-configuration";
 
     public $resource = null;
-    
+
     protected $audience = null;
-    
+
     protected $responseType = 'code';
     protected $responseMode;
-    
+
     public $openIdConfiguration = null;
 
     public function __construct(array $options = [], array $collaborators = [])
     {
-        if(isset($options['metadata'])) {
+        if (isset($options['metadata'])) {
             $this->metadata = $options['metadata'];
         }
-        if(isset($options['responseType'])) {
+        if (isset($options['responseType'])) {
             $this->responseType = $options['responseType'];
         }
-        if(isset($options['responseMode'])) {
+        if (isset($options['responseMode'])) {
             $this->responseMode = $options['responseMode'];
         }
-        if(isset($options['audience'])) {
+        if (isset($options['audience'])) {
             $this->audience = $options['audience'];
         }
-        
+
         parent::__construct($options, $collaborators);
         $this->grantFactory->setGrant('jwt_bearer', new JwtBearer);
         $this->openIdConfiguration = $this->getOpenIdConfiguration($this->metadata);
@@ -55,16 +55,16 @@ class Azure extends AbstractProvider
     {
         return $this->openIdConfiguration['token_endpoint'];
     }
-    
+
     public function getAccessToken($grant, array $options = [])
     {
         // If we are requesting a resource (set as $provider->resource) or passing it on our own in case of multipurpose refresh tokens
-        if($this->resource != null && !isset($options['resource'])) {
+        if ($this->resource != null && !isset($options['resource'])) {
             $options['resource'] = $this->resource;
         }
         return parent::getAccessToken($grant, $options);
     }
-    
+
     protected function getAuthorizationParameters(array $options)
     {
         if (empty($options['state'])) {
@@ -74,7 +74,7 @@ class Azure extends AbstractProvider
             $options['scope'] = $this->getDefaultScopes();
         }
         $options['response_type'] = $this->responseType;
-        if(isset($this->responseMode)) $options['response_mode'] = $this->responseMode;
+        if (isset($this->responseMode)) $options['response_mode'] = $this->responseMode;
         if (is_array($options['scope'])) {
             $separator = $this->getScopeSeparator();
             $options['scope'] = implode($separator, $options['scope']);
@@ -84,7 +84,7 @@ class Azure extends AbstractProvider
         $options['client_id'] = $this->clientId;
         $options['redirect_uri'] = $this->redirectUri;
         $options['state'] = $this->state;
-        
+
         return $options;
     }
 
@@ -98,7 +98,7 @@ class Azure extends AbstractProvider
             } else {
                 $message = $response->getReasonPhrase();
             }
-            
+
             throw new IdentityProviderException(
                 $message,
                 $response->getStatusCode(),
@@ -112,27 +112,27 @@ class Azure extends AbstractProvider
         return [];
     }
 
-  	protected function getScopeSeparator()
-  	{
-  		return ' ';
-  	}
-    
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
+
     protected function createAccessToken(array $response, AbstractGrant $grant)
     {
         return new AccessToken($response, $this);
     }
-    
+
     public function createToken(array $response)
     {
         return new AccessToken($response, $this);
     }
-    
+
     public function getResourceOwner(\League\OAuth2\Client\Token\AccessToken $token)
     {
         $data = $token->getIdTokenClaims();
         return $this->createResourceOwner($data, $token);
     }
-    
+
     public function getResourceOwnerDetailsUrl(\League\OAuth2\Client\Token\AccessToken $token)
     {
         return null;
@@ -146,16 +146,16 @@ class Azure extends AbstractProvider
     public function getObjects($tenant, $ref, &$accessToken, $headers = [])
     {
         $objects = [];
-        
+
         $response = null;
         do {
             if (filter_var($ref, FILTER_VALIDATE_URL) === FALSE) {
-                $ref = $tenant."/".$ref;
+                $ref = $tenant . "/" . $ref;
             }
-            
+
             $response = $this->request('get', $ref, $accessToken, ['headers' => $headers]);
             $values = $response;
-            if(isset($response['value'])) $values = $response['value'];
+            if (isset($response['value'])) $values = $response['value'];
             foreach ($values as $value) {
                 $objects[] = $value;
             }
@@ -163,12 +163,11 @@ class Azure extends AbstractProvider
                 $ref = $response['odata.nextLink'];
             } elseif (isset($response['@odata.nextLink'])) {
                 $ref = $response['@odata.nextLink'];
-            }
-            else {
+            } else {
                 $ref = null;
             }
         } while ($ref != null);
-        
+
         return $objects;
     }
 
@@ -219,13 +218,13 @@ class Azure extends AbstractProvider
         if (filter_var($ref, FILTER_VALIDATE_URL) !== FALSE) {
             $url = $ref;
         } else {
-            $url = $this->resource.$ref;
+            $url = $this->resource . $ref;
         }
 
-        if(isset($options['body']) && (gettype($options['body']) == 'array' || gettype($options['body']) == 'object')) {
+        if (isset($options['body']) && (gettype($options['body']) == 'array' || gettype($options['body']) == 'object')) {
             $options['body'] = json_encode($options['body']);
         }
-        if(!isset($options['headers']['Content-Type']) && isset($options['body'])) {
+        if (!isset($options['headers']['Content-Type']) && isset($options['body'])) {
             $options['headers']['Content-Type'] = 'application/json';
         }
 
@@ -245,22 +244,22 @@ class Azure extends AbstractProvider
 
         return $response;
     }
-    
+
     public function getClientId()
     {
         return $this->clientId;
     }
-    
+
     protected function appendQuery($url, $query)
     {
         $query = trim($query, '?&');
         if ($query) {
-            if(strpos($url, '?') !== FALSE) return $url."&".$query;
-            else return $url."?".$query;
+            if (strpos($url, '?') !== FALSE) return $url . "&" . $query;
+            else return $url . "?" . $query;
         }
         return $url;
     }
-    
+
     /**
      * Obtain URL for logging out the user.
      *
@@ -271,14 +270,14 @@ class Azure extends AbstractProvider
     public function getLogoutUrl($post_logout_redirect_uri = null)
     {
         $url = $this->openIdConfiguration['end_session_endpoint'];
-        if($post_logout_redirect_uri) {
-            if(strpos($url, '?') !== FALSE) $url .= "&";
+        if ($post_logout_redirect_uri) {
+            if (strpos($url, '?') !== FALSE) $url .= "&";
             else $url .= "?";
-            $url .= 'post_logout_redirect_uri='.rawurlencode($post_logout_redirect_uri);
+            $url .= 'post_logout_redirect_uri=' . rawurlencode($post_logout_redirect_uri);
         }
         return $url;
     }
-    
+
     /**
      * Validate the ID token you received in your application.
      *
@@ -294,21 +293,21 @@ class Azure extends AbstractProvider
 
         foreach ($jwks['keys'] as $i => $key) {
             try {
-				        if ( null == $key['x5c'] ) {
-					          throw new \RuntimeException( 'key does not contain the x5c attribute' );
-				        }
-								$key_der = $key['x5c'][0];
-				        $key_pem = chunk_split( $key_der, 64, "\n" );
-				        $key_pem = "-----BEGIN CERTIFICATE-----\n" . $key_pem  . "-----END CERTIFICATE-----\n";
-				        $jwt = (array) JWT::decode( $id_token, $key_pem, array('HS256','HS384','HS512','RS256'));
-				        break;
-			      } catch ( Exception $e ) {
-				        $last_exception = $e;
-			      }
-		    }
-		    if ( null == $jwt ) {
-			      throw $last_exception;
-		    }
+                if (null == $key['x5c']) {
+                    throw new \RuntimeException('key does not contain the x5c attribute');
+                }
+                $key_der = $key['x5c'][0];
+                $key_pem = chunk_split($key_der, 64, "\n");
+                $key_pem = "-----BEGIN CERTIFICATE-----\n" . $key_pem . "-----END CERTIFICATE-----\n";
+                $jwt = (array)JWT::decode($id_token, $key_pem, array('HS256', 'HS384', 'HS512', 'RS256'));
+                break;
+            } catch (Exception $e) {
+                $last_exception = $e;
+            }
+        }
+        if (null == $jwt) {
+            throw $last_exception;
+        }
         if ($this->audience && $this->audience != $jwt['aud']) {
             throw new \RuntimeException("The audience is invalid!");
         }
@@ -319,24 +318,25 @@ class Azure extends AbstractProvider
     }
 
     /**
-	   * Get OAuth2 URLs from Azure Active Directory.
-	   *
-	   * @return array
-	   */
+     * Get OAuth2 URLs from Azure Active Directory.
+     *
+     * @return array
+     */
     public function getOpenIdConfiguration($metadata)
     {
         $factory = $this->getRequestFactory();
         $request = $factory->getRequestWithOptions('get', $metadata, []);
-        
+
         $response = $this->getResponse($request);
-        
-        return json_decode($response->getBody(),true);
+
+        return json_decode($response->getBody(), true);
     }
 
-    private function convert_base64url_to_base64($data) {
-		return str_pad(strtr($data, '-_', '+/'), strlen($data) % 4, '=', STR_PAD_RIGHT);
-	}
-    
+    private function convert_base64url_to_base64($data)
+    {
+        return str_pad(strtr($data, '-_', '+/'), strlen($data) % 4, '=', STR_PAD_RIGHT);
+    }
+
     /**
      * Get JWT verification keys from Azure Active Directory.
      *
@@ -346,9 +346,9 @@ class Azure extends AbstractProvider
     {
         $factory = $this->getRequestFactory();
         $request = $factory->getRequestWithOptions('get', $endpoint, []);
-        
+
         $response = $this->getResponse($request);
-        
-        return json_decode($response->getBody(),true);
+
+        return json_decode($response->getBody(), true);
     }
 }

--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -317,7 +317,12 @@ class Azure extends AbstractProvider
         
         return $tokenClaims;
     }
-    
+
+    /**
+	   * Get OAuth2 URLs from Azure Active Directory.
+	   *
+	   * @return array
+	   */
     public function getOpenIdConfiguration($metadata)
     {
         $factory = $this->getRequestFactory();
@@ -325,7 +330,7 @@ class Azure extends AbstractProvider
         
         $response = $this->getResponse($request);
         
-        return $response;
+        return json_decode($response->getBody(),true);
     }
 
     private function convert_base64url_to_base64($data) {
@@ -344,6 +349,6 @@ class Azure extends AbstractProvider
         
         $response = $this->getResponse($request);
         
-        return $response;
+        return json_decode($response->getBody(),true);
     }
 }


### PR DESCRIPTION
This PR gets the v2.0.0 branch of oauth2-azure functioning and usable. I've broken it into commits to hopefully help check what I've done.

- 52bfdee
Corrects the response of `getOpenIdConfiguration()` and `getJwtVerificationKeys()` from an obect to an array. Addresses #55.
- 3fd3b0a
Adds `getScopeSeparator()` function so that scopes in an array are separated in the authorization url by spaces not commas.
- f3d4fe1
Fixes `validateToken()` so that the idToken is correctly decoded and verified by the firebase/jwt package. As improvements I removed the `nbf` and `exp` checks as firebase/jwt verifies theses already during the decode. Also added a new check that verifies the token issuer `iss` as it is recommended but firebase/jwt doesn't do it.
- The last commit is just to improve code styling consistency.

I have tested using the following code with PHP 7.2 ONLY:
```
$provider = new TheNetworg\OAuth2\Client\Provider\Azure([
    'clientId' => 'foo',
    'clientSecret' => 'foo',
    'redirectUri' => 'foo',
    'metadata' => 'https://login.microsoftonline.com/{tenant-id}/v2.0/.well-known/openid-configuration',
    'responseType' => 'id_token code',
    'responseMode' => 'form_post',
]);
if (!isset($_REQUEST['code'])) {
    try {
        $authorizationUrl = $provider->getAuthorizationUrl([
            'scope' => [
                'openid', 'email', 'profile',
                'https://graph.microsoft.com/user.read',
                'https://graph.microsoft.com/user.read.all',
            ]
        ]);
    } catch (Exception $e) {
        echo $e->getMessage();
    }
    $_SESSION['oauth2state'] = $provider->getState();
    header('Location: ' . $authorizationUrl);
    exit;
} elseif (empty($_REQUEST['state']) || (isset($_SESSION['oauth2state']) && $_REQUEST['state'] !== $_SESSION['oauth2state'])) {
    if (isset($_SESSION['oauth2state'])) {
        unset($_SESSION['oauth2state']);
    }
    exit('Invalid state');
} else {
    $token = $provider->getAccessToken('authorization_code', [
        'code' => $_REQUEST['code']
    ]);
}

/* I receive the access token fine and the following all work */

echo "accessToken Expires:<br>";
echo "Expired in: " . $token->getExpires() . "<br>";
echo "Already expired? " . ($token->hasExpired() ? 'expired' : 'not expired') . "<br>";

$resourceOwner = $provider->getResourceOwner($token);
echo "resourceOwner:";
echo "<pre>";
print_r($resourceOwner->toArray());
echo "</pre>";

try {
    $request = $provider->getAuthenticatedRequest(
        'get','https://graph.microsoft.com/beta/me',$token
    );
    $response = $provider->getResponse($request);
    echo "API Response: <br>";
    echo "<pre>";
    print_r(json_decode($response->getBody(),true););
    echo "</pre>";
} catch (Exception $e) {
    echo $e->getMessage();
}
```