### PR TITLE
Support endpoint v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ header('Location: '.$logoutUrl); // Redirect the user to the generated URL
 #### Call on behalf of a token provided by another app
 
 ```php
-$suppliedToken = ''; // Use token provided by the other app
+// Use token provided by the other app
+// Make sure the other app mentioned this app in the scope when requesting the token
+$suppliedToken = '';  
 
 $provider = xxxxx;// Initialize provider
 

--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -246,9 +246,9 @@ class Azure extends AbstractProvider
             if (isset($keyinfo['x5c']) && is_array($keyinfo['x5c'])) {
                 foreach ($keyinfo['x5c'] as $encodedkey) {
                     $cert =
-                        "-----BEGIN CERTIFICATE-----\r\n"
-                        . chunk_split($encodedkey,64)
-                        . "-----END CERTIFICATE-----\r\n";
+                        '-----BEGIN CERTIFICATE-----' . PHP_EOL
+                        . chunk_split($encodedkey, 64,  PHP_EOL)
+                        . '-----END CERTIFICATE-----' . PHP_EOL;
 
                     $cert_object = openssl_x509_read($cert);
 

--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -13,19 +13,21 @@ use TheNetworg\OAuth2\Client\Token\AccessToken;
 
 class Azure extends AbstractProvider
 {
+    const ENDPOINT_VERSION_1_0 = '1.0';
+    const ENDPOINT_VERSION_2_0 = '2.0';
+
     use BearerAuthorizationTrait;
 
-    public $urlLogin = 'https://login.microsoftonline.com/';
-
-    public $pathAuthorize = '/oauth2/authorize';
-
-    public $pathToken = '/oauth2/token';
+    /** @var array|null */
+    protected $openIdConfiguration;
 
     public $scope = [];
 
     public $scopeSeparator = ' ';
 
     public $tenant = 'common';
+
+    public $defaultEndPointVersion = self::ENDPOINT_VERSION_1_0;
 
     public $urlAPI = 'https://graph.windows.net/';
 
@@ -41,20 +43,55 @@ class Azure extends AbstractProvider
         $this->grantFactory->setGrant('jwt_bearer', new JwtBearer());
     }
 
+    /**
+     * @param string $tenant
+     * @param string $version
+     */
+    protected function getOpenIdConfiguration($tenant, $version) {
+        if (!is_array($this->openIdConfiguration)) {
+            $this->openIdConfiguration = [];
+        }
+        if (!array_key_exists($tenant, $this->openIdConfiguration)) {
+            $this->openIdConfiguration[$tenant] = [];
+        }
+        if (!array_key_exists($version, $this->openIdConfiguration[$tenant])) {
+            $versionInfix = $this->getVersionUriInfix($version);
+            $openIdConfigurationUri = 'https://login.microsoftonline.com/' . $tenant . $versionInfix . '/.well-known/openid-configuration';
+            $factory = $this->getRequestFactory();
+            $request = $factory->getRequestWithOptions(
+                'get',
+                $openIdConfigurationUri,
+                []
+            );
+            $response = $this->getParsedResponse($request);
+            $this->openIdConfiguration[$tenant][$version] = $response;
+        }
+
+        return $this->openIdConfiguration[$tenant][$version];
+    }
+
     public function getBaseAuthorizationUrl()
     {
-        return $this->urlLogin . $this->tenant . $this->pathAuthorize;
+        $openIdConfiguration = $this->getOpenIdConfiguration($this->tenant, $this->defaultEndPointVersion);
+        return $openIdConfiguration['authorization_endpoint'];
     }
 
     public function getBaseAccessTokenUrl(array $params)
     {
-        return $this->urlLogin . $this->tenant . $this->pathToken;
+        $openIdConfiguration = $this->getOpenIdConfiguration($this->tenant, $this->defaultEndPointVersion);
+        return $openIdConfiguration['token_endpoint'];
     }
 
     public function getAccessToken($grant, array $options = [])
     {
-        if ($this->authWithResource) {
-            $options['resource'] = $this->resource ? $this->resource : $this->urlAPI;
+        if ($this->defaultEndPointVersion != self::ENDPOINT_VERSION_2_0) {
+            // Version 2.0 does not support the resources parameter
+            // https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
+            // while version 1.0 does recommend it
+            // https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code
+            if ($this->authWithResource) {
+                $options['resource'] = $this->resource ? $this->resource : $this->urlAPI;
+            }
         }
         return parent::getAccessToken($grant, $options);
     }
@@ -97,6 +134,24 @@ class Azure extends AbstractProvider
         } while (null != $ref);
 
         return $objects;
+    }
+
+    /**
+     * @param $accessToken AccessToken|null
+     * @return string
+     */
+    public function getRootMicrosoftGraphUri($accessToken)
+    {
+        if (is_null($accessToken)) {
+            $tenant = $this->tenant;
+            $version = $this->defaultEndPointVersion;
+        } else {
+            $idTokenClaims = $accessToken->getIdTokenClaims();
+            $tenant = array_key_exists('tid', $idTokenClaims) ? $idTokenClaims['tid'] : $this->tenant;
+            $version = array_key_exists('ver', $idTokenClaims) ? $idTokenClaims['ver'] : $this->defaultEndPointVersion;
+        }
+        $openIdConfiguration = $this->getOpenIdConfiguration($tenant, $version);
+        return 'https://' . $openIdConfiguration['msgraph_host'];
     }
 
     public function get($ref, &$accessToken, $headers = [])
@@ -189,7 +244,10 @@ class Azure extends AbstractProvider
      */
     public function getLogoutUrl($post_logout_redirect_uri)
     {
-        return 'https://login.microsoftonline.com/' . $this->tenant . '/oauth2/logout?post_logout_redirect_uri=' . rawurlencode($post_logout_redirect_uri);
+        $openIdConfiguration = $this->getOpenIdConfiguration($this->tenant, $this->defaultEndPointVersion);
+        $logoutUri = $openIdConfiguration['end_session_endpoint'];
+
+        return $logoutUri . '?post_logout_redirect_uri=' . rawurlencode($post_logout_redirect_uri);
     }
 
     /**
@@ -204,6 +262,19 @@ class Azure extends AbstractProvider
         $keys        = $this->getJwtVerificationKeys();
         $tokenClaims = (array)JWT::decode($accessToken, $keys, ['RS256']);
 
+        $this->validateTokenClaims($tokenClaims);
+
+        return $tokenClaims;
+    }
+
+    /**
+     * Validate the access token claims from an access token you received in your application.
+     *
+     * @param $tokenClaims array The token claims from an access token you received in the authorization header.
+     *
+     * @return void
+     */
+    public function validateTokenClaims($tokenClaims) {
         if ($this->getClientId() != $tokenClaims['aud'] && $this->getClientId() != $tokenClaims['appid']) {
             throw new \RuntimeException('The client_id / audience is invalid!');
         }
@@ -214,19 +285,13 @@ class Azure extends AbstractProvider
 
         if ('common' == $this->tenant) {
             $this->tenant = $tokenClaims['tid'];
-
-            $tenant = $this->getTenantDetails($this->tenant);
-            if ($tokenClaims['iss'] != $tenant['issuer']) {
-                throw new \RuntimeException('Invalid token issuer!');
-            }
-        } else {
-            $tenant = $this->getTenantDetails($this->tenant);
-            if ($tokenClaims['iss'] != $tenant['issuer']) {
-                throw new \RuntimeException('Invalid token issuer!');
-            }
         }
 
-        return $tokenClaims;
+        $version = array_key_exists('ver', $tokenClaims) ? $tokenClaims['ver'] : $this->defaultEndPointVersion;
+        $tenant = $this->getTenantDetails($this->tenant, $version);
+        if ($tokenClaims['iss'] != $tenant['issuer']) {
+            throw new \RuntimeException('Invalid token issuer (tokenClaims[iss]' . $tokenClaims['iss'] . ', tenant[issuer] ' . $tenant['issuer'] . ')!');
+        }
     }
 
     /**
@@ -236,8 +301,11 @@ class Azure extends AbstractProvider
      */
     public function getJwtVerificationKeys()
     {
+        $openIdConfiguration = $this->getOpenIdConfiguration($this->tenant, $this->defaultEndPointVersion);
+        $keysUri = $openIdConfiguration['jwks_uri'];
+
         $factory = $this->getRequestFactory();
-        $request = $factory->getRequestWithOptions('get', 'https://login.windows.net/common/discovery/keys', []);
+        $request = $factory->getRequestWithOptions('get', $keysUri, []);
 
         $response = $this->getParsedResponse($request);
 
@@ -278,25 +346,25 @@ class Azure extends AbstractProvider
         return $keys;
     }
 
+    protected function getVersionUriInfix($version)
+    {
+        return
+            ($version == self::ENDPOINT_VERSION_2_0)
+                ? '/v' . self::ENDPOINT_VERSION_2_0
+                : '';
+    }
+
     /**
      * Get the specified tenant's details.
      *
      * @param string $tenant
+     * @param string|null $version
      *
      * @return array
      */
-    public function getTenantDetails($tenant)
+    public function getTenantDetails($tenant, $version)
     {
-        $factory = $this->getRequestFactory();
-        $request = $factory->getRequestWithOptions(
-            'get',
-            'https://login.windows.net/' . $tenant . '/.well-known/openid-configuration',
-            []
-        );
-
-        $response = $this->getParsedResponse($request);
-
-        return $response;
+        return $this->getOpenIdConfiguration($this->tenant, $this->defaultEndPointVersion);
     }
 
     protected function checkResponse(ResponseInterface $response, $data)

--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -38,27 +38,8 @@ class AccessToken extends \League\OAuth2\Client\Token\AccessToken
             } catch (JWT_Exception $e) {
                 throw new RuntimeException('Unable to parse the id_token!');
             }
-            if ($provider->getClientId() != $idTokenClaims['aud']) {
-                throw new RuntimeException('The audience is invalid!');
-            }
-            if ($idTokenClaims['nbf'] > time() || $idTokenClaims['exp'] < time()) {
-                // Additional validation is being performed in firebase/JWT itself
-                throw new RuntimeException('The id_token is invalid!');
-            }
 
-            if ('common' == $provider->tenant) {
-                $provider->tenant = $idTokenClaims['tid'];
-
-                $tenant = $provider->getTenantDetails($provider->tenant);
-                if ($idTokenClaims['iss'] != $tenant['issuer']) {
-                    throw new RuntimeException('Invalid token issuer!');
-                }
-            } else {
-                $tenant = $provider->getTenantDetails($provider->tenant);
-                if ($idTokenClaims['iss'] != $tenant['issuer']) {
-                    throw new RuntimeException('Invalid token issuer!');
-                }
-            }
+            $provider->validateTokenClaims($idTokenClaims);
 
             $this->idTokenClaims = $idTokenClaims;
         }


### PR DESCRIPTION
Improve the library by:
- Adding support for v2.0 of AAD endpoints. The initial value is set via Azure::defaultEndPointVersion.
- Grabing most urls from an official /.well-known/openid-configuration endpoint instead of having them hard coded. 
- Resolved duplication of code in AccessToken::__construct and Azure::validateAccessToken.
- Added a helper method to retrieve Microsoft Graph root url from the /.well-known/openid-configuration endpoint.

Support for end points is not ideal as the underlying library does not provide necessary data when calling getBaseAuthorizationUrl, getBaseAccessTokenUrl etc. as the version should be determined by the token's `ver` value but the value nor the token is provided when calling these methods.