### PR TITLE
Add error description to message to improve exception quality

### DIFF
--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -325,6 +325,10 @@ class Azure extends AbstractProvider
                 $message = $response->getReasonPhrase();
             }
 
+            if (isset($data['error_description']) && !is_array($data['error_description'])) {
+                $message .= PHP_EOL . $data['error_description'];
+            }
+
             throw new IdentityProviderException(
                 $message,
                 $response->getStatusCode(),


### PR DESCRIPTION
In case of a misconfiguration one does only get an "invalid_client" as messages which can be anything [regarding to Microsoft](https://github.com/Azure-Samples/active-directory-error-docs/wiki/invalid_client).

With the description in addition you can get helpful messages like:
```
invalid_client
AADSTS50011: The reply URL specified in the request does not match the reply URLs configured for the application: '12345678-1234-1234-1234-1234567890ab'.
  Trace ID: 12345678-1234-1234-1234-1234567890ab
  Correlation ID: 12345678-1234-1234-1234-1234567890ab
  Timestamp: 2020-01-07 10:00:00Z
```