### PR TITLE
Remove app id validation

### DIFF
--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -281,15 +281,7 @@ class Azure extends AbstractProvider
      * @return void
      */
     public function validateTokenClaims($tokenClaims) {
-        $version = array_key_exists('ver', $tokenClaims) ? $tokenClaims['ver'] : $this->defaultEndPointVersion;
-
-        if ($version == self::ENDPOINT_VERSION_1_0) {
-            $appId = $tokenClaims['appid'];
-        } else {
-            $appId = $tokenClaims['azp'];
-        }
-
-        if ($this->getClientId() != $tokenClaims['aud'] && $this->getClientId() != $appId) {
+        if ($this->getClientId() != $tokenClaims['aud']) {
             throw new \RuntimeException('The client_id / audience is invalid!');
         }
         if ($tokenClaims['nbf'] > time() || $tokenClaims['exp'] < time()) {
@@ -301,6 +293,7 @@ class Azure extends AbstractProvider
             $this->tenant = $tokenClaims['tid'];
         }
 
+        $version = array_key_exists('ver', $tokenClaims) ? $tokenClaims['ver'] : $this->defaultEndPointVersion;
         $tenant = $this->getTenantDetails($this->tenant, $version);
         if ($tokenClaims['iss'] != $tenant['issuer']) {
             throw new \RuntimeException('Invalid token issuer (tokenClaims[iss]' . $tokenClaims['iss'] . ', tenant[issuer] ' . $tenant['issuer'] . ')!');

--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -281,7 +281,15 @@ class Azure extends AbstractProvider
      * @return void
      */
     public function validateTokenClaims($tokenClaims) {
-        if ($this->getClientId() != $tokenClaims['aud'] && $this->getClientId() != $tokenClaims['appid']) {
+        $version = array_key_exists('ver', $tokenClaims) ? $tokenClaims['ver'] : $this->defaultEndPointVersion;
+
+        if ($version == self::ENDPOINT_VERSION_1_0) {
+            $appId = $tokenClaims['appid'];
+        } else {
+            $appId = $tokenClaims['azp'];
+        }
+
+        if ($this->getClientId() != $tokenClaims['aud'] && $this->getClientId() != $appId) {
             throw new \RuntimeException('The client_id / audience is invalid!');
         }
         if ($tokenClaims['nbf'] > time() || $tokenClaims['exp'] < time()) {
@@ -293,7 +301,6 @@ class Azure extends AbstractProvider
             $this->tenant = $tokenClaims['tid'];
         }
 
-        $version = array_key_exists('ver', $tokenClaims) ? $tokenClaims['ver'] : $this->defaultEndPointVersion;
         $tenant = $this->getTenantDetails($this->tenant, $version);
         if ($tokenClaims['iss'] != $tenant['issuer']) {
             throw new \RuntimeException('Invalid token issuer (tokenClaims[iss]' . $tokenClaims['iss'] . ', tenant[issuer] ' . $tenant['issuer'] . ')!');


### PR DESCRIPTION
Use correct claim based on token version to validate application ID.
- v1 token have application id in appid claim
- v2 token have application id in azp claim.

Doc: https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#claims-in-access-tokens