### PR TITLE
Allow to set some params in list of options in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ Usage is the same as The League's OAuth client, using `\TheNetworg\OAuth2\Client
 $provider = new TheNetworg\OAuth2\Client\Provider\Azure([
     'clientId'          => '{azure-client-id}',
     'clientSecret'      => '{azure-client-secret}',
-    'redirectUri'       => 'https://example.com/callback-url'
+    'redirectUri'       => 'https://example.com/callback-url',
+    //Optional
+    'scopes'            => 'openid',
+    //Optional
+    'defaultEndPointVersion' => '2.0'
 ]);
 
 // Set to use v2 API, skip the line or set the value to Azure::ENDPOINT_VERSION_1_0 if willing to use v1 API

--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -15,7 +15,8 @@ class Azure extends AbstractProvider
 {
     const ENDPOINT_VERSION_1_0 = '1.0';
     const ENDPOINT_VERSION_2_0 = '2.0';
-  
+    const ENDPOINT_VERSIONS = [self::ENDPOINT_VERSION_1_0, self::ENDPOINT_VERSION_2_0];
+
     use BearerAuthorizationTrait;
 
     public $urlLogin = 'https://login.microsoftonline.com/';
@@ -42,6 +43,13 @@ class Azure extends AbstractProvider
     public function __construct(array $options = [], array $collaborators = [])
     {
         parent::__construct($options, $collaborators);
+        if (isset($options['scopes'])) {
+            $this->scope = array_merge($options['scopes'], $this->scope);
+        }
+        if (isset($options['defaultEndPointVersion']) &&
+            in_array($options['defaultEndPointVersion'], self::ENDPOINT_VERSIONS, true)) {
+            $this->defaultEndPointVersion = $options['defaultEndPointVersion'];
+        }
         $this->grantFactory->setGrant('jwt_bearer', new JwtBearer());
     }
 


### PR DESCRIPTION
Hi,
We are using simplesamlphp module(https://github.com/cirrusidentity/simplesamlphp-module-authoauth2) with some oauth2-clients.
We want to use your client for AzureAD, but we need the possibility to set scopes and defaultEndPointVersion from the 'options' field in the constructor.

This PR allows setting the 'scopes' and  'defaultEndPointVersion' from the constructor.

Thanks for the review.