### PR TITLE
Fix: make scopes value an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $provider = new TheNetworg\OAuth2\Client\Provider\Azure([
     'clientSecret'      => '{azure-client-secret}',
     'redirectUri'       => 'https://example.com/callback-url',
     //Optional
-    'scopes'            => 'openid',
+    'scopes'            => ['openid'],
     //Optional
     'defaultEndPointVersion' => '2.0'
 ]);


### PR DESCRIPTION
array_merge() expects scopes value in options to be an array
See: https://github.com/TheNetworg/oauth2-azure/blob/2649422a0dc74af32d21d9d738d37abcd5b03998/src/Provider/Azure.php#L47