### PR TITLE
Add method to retrieve raw id_token from AccessToken object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 composer.phar
 composer.lock
 .DS_Store
+
+# IDE
+/.idea
+/.vscode

--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -19,6 +19,8 @@ class AccessToken extends \League\OAuth2\Client\Token\AccessToken
         if (!empty($options['id_token'])) {
             $this->idToken = $options['id_token'];
 
+            unset($this->values['id_token']);
+
             $keys          = $provider->getJwtVerificationKeys();
             $idTokenClaims = null;
             try {

--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -45,6 +45,11 @@ class AccessToken extends \League\OAuth2\Client\Token\AccessToken
         }
     }
 
+    public function getIdToken()
+    {
+        return $this->idToken;
+    }
+
     public function getIdTokenClaims()
     {
         return $this->idTokenClaims;


### PR DESCRIPTION
It would be convenient to be able to retrieve the `id_token` raw string directly from the `AccessToken` object (consistent with other methods: `getToken()` & `getRefreshToken()`).

**Before:**
```php
$token->getValues()['id_token'];
```

**After:**
```php
$token->getIdToken();
```

Note: afe3b06 (unsetting from `$this->values`) is a breaking change - I'm happy to revert this if needed.