### PR TITLE
Remove Deprecations for PHP 8.1 / ditch PHP 5.6 and 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
         "sso"
     ],
     "require": {
-        "php": "^5.6|^7.0|^8.0",
+        "ext-json": "*",
+        "ext-openssl": "*",
+        "php": "^7.1|^8.0",
         "league/oauth2-client": "~2.0",
         "firebase/php-jwt": "~3.0||~4.0||~5.0"
     },

--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -6,6 +6,8 @@ use Firebase\JWT\JWT;
 use League\OAuth2\Client\Grant\AbstractGrant;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use League\OAuth2\Client\Token\AccessTokenInterface;
 use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
 use Psr\Http\Message\ResponseInterface;
 use TheNetworg\OAuth2\Client\Grant\JwtBearer;
@@ -80,19 +82,28 @@ class Azure extends AbstractProvider
         return $this->openIdConfiguration[$tenant][$version];
     }
 
-    public function getBaseAuthorizationUrl()
+    /**
+     * @inheritdoc
+     */
+    public function getBaseAuthorizationUrl(): string
     {
         $openIdConfiguration = $this->getOpenIdConfiguration($this->tenant, $this->defaultEndPointVersion);
         return $openIdConfiguration['authorization_endpoint'];
     }
 
-    public function getBaseAccessTokenUrl(array $params)
+    /**
+     * @inheritdoc
+     */
+    public function getBaseAccessTokenUrl(array $params): string
     {
         $openIdConfiguration = $this->getOpenIdConfiguration($this->tenant, $this->defaultEndPointVersion);
         return $openIdConfiguration['token_endpoint'];
     }
 
-    public function getAccessToken($grant, array $options = [])
+    /**
+     * @inheritdoc
+     */
+    public function getAccessToken($grant, array $options = []): AccessTokenInterface
     {
         if ($this->defaultEndPointVersion != self::ENDPOINT_VERSION_2_0) {
             // Version 2.0 does not support the resources parameter
@@ -106,14 +117,21 @@ class Azure extends AbstractProvider
         return parent::getAccessToken($grant, $options);
     }
 
-    public function getResourceOwner(\League\OAuth2\Client\Token\AccessToken $token)
+    /**
+     * @inheritdoc
+     */
+    public function getResourceOwner(\League\OAuth2\Client\Token\AccessToken $token): ResourceOwnerInterface
     {
         $data = $token->getIdTokenClaims();
         return $this->createResourceOwner($data, $token);
     }
 
-    public function getResourceOwnerDetailsUrl(\League\OAuth2\Client\Token\AccessToken $token)
+    /**
+     * @inheritdoc
+     */
+    public function getResourceOwnerDetailsUrl(\League\OAuth2\Client\Token\AccessToken $token): string
     {
+        return ''; // shouldn't that return such a URL?
     }
 
     public function getObjects($tenant, $ref, &$accessToken, $headers = [])
@@ -382,7 +400,10 @@ class Azure extends AbstractProvider
         return $this->getOpenIdConfiguration($this->tenant, $this->defaultEndPointVersion);
     }
 
-    protected function checkResponse(ResponseInterface $response, $data)
+    /**
+     * @inheritdoc
+     */
+    protected function checkResponse(ResponseInterface $response, $data): void
     {
         if (isset($data['odata.error']) || isset($data['error'])) {
             if (isset($data['odata.error']['message']['value'])) {
@@ -402,27 +423,39 @@ class Azure extends AbstractProvider
             throw new IdentityProviderException(
                 $message,
                 $response->getStatusCode(),
-                $response
+                $response->getBody()
             );
         }
     }
 
-    protected function getDefaultScopes()
+    /**
+     * @inheritdoc
+     */
+    protected function getDefaultScopes(): array
     {
         return $this->scope;
     }
 
-    protected function getScopeSeparator()
+    /**
+     * @inheritdoc
+     */
+    protected function getScopeSeparator(): string
     {
         return $this->scopeSeparator;
     }
 
-    protected function createAccessToken(array $response, AbstractGrant $grant)
+    /**
+     * @inheritdoc
+     */
+    protected function createAccessToken(array $response, AbstractGrant $grant): AccessToken
     {
         return new AccessToken($response, $this);
     }
 
-    protected function createResourceOwner(array $response, \League\OAuth2\Client\Token\AccessToken $token)
+    /**
+     * @inheritdoc
+     */
+    protected function createResourceOwner(array $response, \League\OAuth2\Client\Token\AccessToken $token): AzureResourceOwner
     {
         return new AzureResourceOwner($response);
     }


### PR DESCRIPTION
Removes the deprecation notices raised by PHP 8.1.

And ditch very end of life PHP versions 5.6 and 7.0 to support the missing return types that raised the deprecation notices in PHP 8.1.

Also fixes a small bug inside `Azure::checkResponse()` that was found by the static code analysis.

See #154 