### PR TITLE
Firebase 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^5.6|^7.0|^8.0",
         "league/oauth2-client": "~2.0",
-        "firebase/php-jwt": "~3.0||~4.0||~5.0"
+        "firebase/php-jwt": "~3.0||~4.0||~5.0||~6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Allows firebase 6.x to be installed and fixes insecure encryption issue.

firebase/php-jwt@5.5.1 is vulnerable to Insecure Encryption due to an algorithm-confusion issue (e.g., RS256 / HS256) that exists via the kid (aka Key ID) header when multiple types of keys are loaded in a key ring. This allows an attacker to forge tokens that validate under the incorrect key.  This vulnerability is fixed in firebase/php-jwt@6.0.0.

![Screen Shot 2022-05-02 at 5 00 19 PM](https://user-images.githubusercontent.com/1591839/166334369-7898cad5-f78e-46cd-ad6d-53c68dc657c3.png)
