### PR TITLE
Handle empty ID token claim

### DIFF
--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -217,8 +217,8 @@ class Azure extends AbstractProvider
             $version = $this->defaultEndPointVersion;
         } else {
             $idTokenClaims = $accessToken->getIdTokenClaims();
-            $tenant = array_key_exists('tid', $idTokenClaims) ? $idTokenClaims['tid'] : $this->tenant;
-            $version = array_key_exists('ver', $idTokenClaims) ? $idTokenClaims['ver'] : $this->defaultEndPointVersion;
+            $tenant = is_array($idTokenClaims) && array_key_exists('tid', $idTokenClaims) ? $idTokenClaims['tid'] : $this->tenant;
+            $version = is_array($idTokenClaims) && array_key_exists('ver', $idTokenClaims) ? $idTokenClaims['ver'] : $this->defaultEndPointVersion;
         }
         $openIdConfiguration = $this->getOpenIdConfiguration($tenant, $version);
         return 'https://' . $openIdConfiguration['msgraph_host'];


### PR DESCRIPTION
AccessToken::getIdTokenClaims() can return null, but Azure::getRootMicrosoftGraphUri() expected an array. This caused `array_key_exists(): Argument #2 ($array) must be of type array, null given` error when the access token had no claims.