### PR TITLE
use JWT timestamp to validate claims

### DIFF
--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -349,10 +349,13 @@ class Azure extends AbstractProvider
      * @return void
      */
     public function validateTokenClaims($tokenClaims) {
+        $timestamp = \is_null(JWT::$timestamp) ? \time() : JWT::$timestamp;
+
         if ($this->getClientId() != $tokenClaims['aud']) {
             throw new \RuntimeException('The client_id / audience is invalid!');
         }
-        if ($tokenClaims['nbf'] > time() || $tokenClaims['exp'] < time()) {
+
+        if ($tokenClaims['nbf'] > $timestamp || $tokenClaims['exp'] < $timestamp) {
             // Additional validation is being performed in firebase/JWT itself
             throw new \RuntimeException('The id_token is invalid!');
         }


### PR DESCRIPTION
This allows better testability.

This feature is better described in the `JWT` class :

> Allow the current timestamp to be specified. Useful for fixing a value within unit testing.
> https://github.com/firebase/php-jwt/blob/3b454f90f147db65a615041dec6661f427d6cb00/src/JWT.php#L43-L50