### PR TITLE
Set default algorithm through config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "qbnk/oauth2-azure",
+    "name": "thenetworg/oauth2-azure",
     "description": "Azure Active Directory OAuth 2.0 Client Provider for The PHP League OAuth2-Client",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "thenetworg/oauth2-azure",
+    "name": "qbnk/oauth2-azure",
     "description": "Azure Active Directory OAuth 2.0 Client Provider for The PHP League OAuth2-Client",
     "license": "MIT",
     "authors": [

--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -45,6 +45,8 @@ class Azure extends AbstractProvider
 
     public $authWithResource = true;
 
+    public $defaultAlgorithm = null;
+
     /**
      * The contents of the private key used for app authentication
      * @var string
@@ -66,6 +68,9 @@ class Azure extends AbstractProvider
         if (isset($options['defaultEndPointVersion']) &&
             in_array($options['defaultEndPointVersion'], self::ENDPOINT_VERSIONS, true)) {
             $this->defaultEndPointVersion = $options['defaultEndPointVersion'];
+        }
+        if (isset($options['defaultAlgorithm'])) {
+            $this->defaultAlgorithm = $options['defaultAlgorithm'];
         }
         $this->grantFactory->setGrant('jwt_bearer', new JwtBearer());
     }
@@ -415,7 +420,7 @@ class Azure extends AbstractProvider
                     $keys[$keyinfo['kid']] = new Key($publicKey, 'RS256');
                 }
             } else if (isset($keyinfo['n']) && isset($keyinfo['e'])) {
-                $pkey_object = JWK::parseKey($keyinfo);
+                $pkey_object = JWK::parseKey($keyinfo, $this->defaultAlgorithm);
 
                 if ($pkey_object === false) {
                     throw new \RuntimeException('An attempt to read a public key from a ' . $keyinfo['n'] . ' certificate failed.');

--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -426,7 +426,7 @@ class Azure extends AbstractProvider
                     throw new \RuntimeException('An attempt to read a public key from a ' . $keyinfo['n'] . ' certificate failed.');
                 }
 
-                $pkey_array = openssl_pkey_get_details($pkey_object);
+                $pkey_array = openssl_pkey_get_details($pkey_object->getKeyMaterial());
 
                 if ($pkey_array === false) {
                     throw new \RuntimeException('An attempt to get a public key as an array from a ' . $keyinfo['n'] . ' certificate failed.');


### PR DESCRIPTION
Microsoft's identity platform uses the kty parameter for the encryption family, alg is omitted. This PR gives the ability to set a defaultAlgorithm when `alg` is not included. 

Also passing in correct value to openssl_pkey_get_details() so it won't crash. 

Resolves #172