### PR TITLE
Exclude dev files from dist archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.devcontainer/     export-ignore
+/.vscode/           export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.php_cs            export-ignore


### PR DESCRIPTION
Dist archives fetched from composer using `--prefer-dist` are containing files that only usefull on dev environments.
Adding these git attributes will permit to remove them from dist archives.