### PR TITLE
Update Azure.php

### DIFF
--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -178,7 +178,8 @@ class Azure extends AbstractProvider
      */
     public function getResourceOwnerDetailsUrl(\League\OAuth2\Client\Token\AccessToken $token): string
     {
-        return ''; // shouldn't that return such a URL?
+        $openIdConfiguration = $this->getOpenIdConfiguration($this->tenant, $this->defaultEndPointVersion);
+        return $openIdConfiguration['userinfo_endpoint'];
     }
 
     public function getObjects($tenant, $ref, &$accessToken, $headers = [])


### PR DESCRIPTION
Hi,

I am implementing openid and I stumbled on this missing return value in getResourceOwnerDetailsUrl(). Other providers (Like Google) return the openid userinfo endpoint here. That way I can login and ask for user info for any provider.

I hope you can merge this simple fix.

Best regards,
Merijn Schering