### PR TITLE
Check for existing query parameters before appending post_logout_redi…

### DIFF
--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -324,7 +324,9 @@ class Azure extends AbstractProvider
         $logoutUri = $openIdConfiguration['end_session_endpoint'];
 
         if (!empty($post_logout_redirect_uri)) {
-            $logoutUri .= '?post_logout_redirect_uri=' . rawurlencode($post_logout_redirect_uri);
+            $query = parse_url($logoutUri, PHP_URL_QUERY);
+            $logoutUri .= $query ? '&' : '?';
+            $logoutUri .= 'post_logout_redirect_uri=' . rawurlencode($post_logout_redirect_uri);
         }
 
         return $logoutUri;


### PR DESCRIPTION
…rect_uri

OpenID configuration URI may contain query parameters (for example p=<b2c policy>), therefore check before appending new query parameters to URI