### PR TITLE
Fix validation error in 'validateTokenClaims' method for accessToken version 2

### DIFF
--- a/src/Provider/Azure.php
+++ b/src/Provider/Azure.php
@@ -89,7 +89,7 @@ class Azure extends AbstractProvider
         if (!array_key_exists($version, $this->openIdConfiguration[$tenant])) {
             $versionInfix = $this->getVersionUriInfix($version);
 	          $openIdConfigurationUri = $this->urlLogin . $tenant . $versionInfix . '/.well-known/openid-configuration?appid=' . $this->clientId;
-            
+
             $factory = $this->getRequestFactory();
             $request = $factory->getRequestWithOptions(
                 'get',
@@ -370,7 +370,7 @@ class Azure extends AbstractProvider
         $version = array_key_exists('ver', $tokenClaims) ? $tokenClaims['ver'] : $this->defaultEndPointVersion;
         $tenant = $this->getTenantDetails($this->tenant, $version);
         if ($tokenClaims['iss'] != $tenant['issuer']) {
-            throw new \RuntimeException('Invalid token issuer (tokenClaims[iss]' . $tokenClaims['iss'] . ', tenant[issuer] ' . $tenant['issuer'] . ')!');
+            throw new \RuntimeException('Invalid token issuer (tokenClaims[iss] ' . $tokenClaims['iss'] . ', tenant[issuer] ' . $tenant['issuer'] . ')!');
         }
     }
 
@@ -466,7 +466,7 @@ class Azure extends AbstractProvider
      */
     public function getTenantDetails($tenant, $version)
     {
-        return $this->getOpenIdConfiguration($this->tenant, $this->defaultEndPointVersion);
+        return $this->getOpenIdConfiguration($this->tenant, $version);
     }
 
     /**


### PR DESCRIPTION
This bug causes a validation error in the 'validateTokenClaims' method if the user forgets to set the 'default_endpoint_version' option to '2' and uses an accessToken version 2.