### PR TITLE
Improve error messages

### DIFF
--- a/tests/Fakers/B2cTokenFaker.php
+++ b/tests/Fakers/B2cTokenFaker.php
@@ -75,7 +75,7 @@ class B2cTokenFaker
               'sub' => $this->fakeData['sub'],
               'tfp' => 'tfp',
               'ver' => '1.0',
-              'iat' => time()
+              'iat' => time(),
             );
 
             $idToken = array(
@@ -90,7 +90,7 @@ class B2cTokenFaker
                 "idp_access_token" => '123',
                 "idp" => "idp",
                 "tfp" => "tfp",
-                "at_hash" => "rfz4eAdZL7I_G8tQBvHI5Q"
+                "at_hash" => "rfz4eAdZL7I_G8tQBvHI5Q",
             );
 
             $encryptedAccessToken = $this->createJWT($accessToken);


### PR DESCRIPTION
Had a terrible Monday morning case of my local development VM missing NTP synchronization, spent 10 minutes figuring out why I was getting vague `The id_token is invalid!` errors all the time.

Improved error messages following Symfony standards: full grammatically correct sentences ending with a period, describing the real problem in detail including the most likely problem and solution.

The change at #369 repairs the broken tests on newer PHP versions (accessing a missing array value is a hard error now without null coalesce).